### PR TITLE
Fix errors on execute 'rake pgdump_scrambler:config_from_db'

### DIFF
--- a/lib/pgdump_scrambler/config.rb
+++ b/lib/pgdump_scrambler/config.rb
@@ -119,7 +119,7 @@ module PgdumpScrambler
             if klass
               columns = klass.columns.map(&:name).reject do |name|
                 IGNORED_ACTIVE_RECORD_COLUMNS.member?(name) ||
-                  IGNORED_ACTIVE_RECORD_COLUMNS_REGEXPS.any? { |regexp| regexp.match?(name) }
+                  IGNORED_ACTIVE_RECORD_COLUMNS_REGEXPS.any? { |regexp| regexp.match(name) }
               end.map do |name|
                 Column.new(name)
               end


### PR DESCRIPTION
```
$ bundle exec rake pgdump_scrambler:config_from_db
craete config from database
rake aborted!
NoMethodError: undefined method `match?' for /_id\z/:Regexp
Did you mean?  match
/Users/keisuke/.rbenv/versions/2.3.5/bin/bundle:22:in `load'
/Users/keisuke/.rbenv/versions/2.3.5/bin/bundle:22:in `<main>'
Tasks: TOP => pgdump_scrambler:config_from_db
(See full trace by running task with --trace)
```