### PR TITLE
Add pgdump_args option

### DIFF
--- a/lib/pgdump_scrambler/dumper.rb
+++ b/lib/pgdump_scrambler/dumper.rb
@@ -35,6 +35,7 @@ module PgdumpScrambler
       command = []
       command << "PGPASSWORD=#{Shellwords.escape(@db_config['password'])}" if @db_config['password']
       command << 'pg_dump'
+      command << @config.pgdump_args if @config.pgdump_args
       command << "--username=#{Shellwords.escape(@db_config['username'])}" if @db_config['username']
       command << "--host='#{@db_config['host']}'" if @db_config['host']
       command << "--port='#{@db_config['port']}'" if @db_config['port']

--- a/spec/pgdump_scrambler_spec.rb
+++ b/spec/pgdump_scrambler_spec.rb
@@ -102,4 +102,22 @@ RSpec.describe PgdumpScrambler do
     config = PgdumpScrambler::Config.read(StringIO.new(yaml))
     expect(config.obfuscator_options).to eq '-c posts:content:sbytes -c posts:title:sbytes -c users:email:uemail'
   end
+
+  it 'pgdump options' do
+    yaml = <<~YAML
+    ---
+    dump_path: scrambled.dump
+    pgdump_args: '-xc'
+    tables:
+      posts:
+        author: nop
+        content: sbytes
+        title: sbytes
+      users:
+        email: uemail
+        name: unspecified
+    YAML
+    config = PgdumpScrambler::Config.read(StringIO.new(yaml))
+    expect(config.pgdump_args).to eq '-xc'
+  end
 end


### PR DESCRIPTION
Add `pgdump_args` option. The value of the option is passed directly to the pg_dump command.
For example, it is assumed that you want to pass the `-c` option to pg_dump.