### PR TITLE
MultiDB用configの場合、primaryを読むように変更

### DIFF
--- a/lib/pgdump_scrambler/dumper.rb
+++ b/lib/pgdump_scrambler/dumper.rb
@@ -49,7 +49,7 @@ module PgdumpScrambler
         db_config = open(Rails.root.join('config', 'database.yml'), 'r') do |f|
           YAML.load(f)
         end
-        db_config[Rails.env]
+        db_config[Rails.env].key?('primary') ? db_config[Rails.env]['primary'] : db_config[Rails.env]
       end
     end
   end


### PR DESCRIPTION
Dumperのdatabase YAML読み込みがMulti DB対応になっていなかったので、Multi DBの場合dumpに失敗していた。
これを修正する。

今までの `config/database.yml`

```
---
production:
  adapter: mysql2
  encoding: utf8
  reconnect: false
  database: sample_mysql_production
  pool: 5
  username: root
  password:
  host: localhost
```

MultiDB用の `config/database.yml`

```
---
production:
  primary:
    adapter: mysql2
    encoding: utf8
    reconnect: false
    database: sample_mysql_production
    pool: 5
    username: root
    password:
    host: localhost
  primary_replica:
    adapter: mysql2
    encoding: utf8
    reconnect: false
    database: sample_mysql_production
    pool: 5
    username: root
    password:
    host: localhost
```